### PR TITLE
Fix header parsing, body performance issue, and 413 behavior

### DIFF
--- a/src/halo2.janet
+++ b/src/halo2.janet
@@ -60,7 +60,7 @@
 (def request-peg
   (peg/compile ~{:main (sequence :request-line :crlf (group (some :headers)) :crlf (opt :body))
                  :request-line (sequence (capture (to :sp)) :sp (capture (to :sp)) :sp "HTTP/" (capture (to :crlf)))
-                 :headers (sequence (capture (to ":")) ": " (capture (to :crlf)) :crlf)
+                 :headers (sequence (not :crlf) (capture (to ":")) ": " (capture (to :crlf)) :crlf)
                  :body (capture (some (if-not -1 1)))
                  :sp " "
                  :crlf ,CRLF}))


### PR DESCRIPTION
This fixes #4 , #6, #7, and #8

It was eagerly consuming the body as a header if it had a colon in it. 
By saying that a header cannot begin with `\r\n`, it should no longer consume the end of the header section on HTTP 1 requests.
