### PR TITLE
Support streaming body contents

### DIFF
--- a/examples/basic.janet
+++ b/examples/basic.janet
@@ -13,11 +13,19 @@
   {:status 302
    :headers @{"Location" "/"}})
 
+
+(defn invalid [request]
+  "Returns an invalid response: structs/tables can't be returned directly as body.
+  They must be converted to string first.
+  This will trigger a 500 Internal Server Error."
+  {:status 200
+   :body {:data "invalid"}})
+
 (defn app [request]
   (case (request :uri)
     "/" (home request)
-
     "/post" (post request)
+    "/invalid" (invalid request)
 
     # anything else is static
     (static request)))

--- a/examples/server-sent-events.janet
+++ b/examples/server-sent-events.janet
@@ -1,0 +1,19 @@
+(import ../src/halo2)
+
+# You can listen to the events in the browser console with:
+# ```js
+# var a = new EventSource("/");
+# a.onmessage = console.log;
+# ```
+
+(defn handler [request]
+  {:status 200 
+   :headers {"Content-Type" "text/event-stream"
+             "Cache-Control" "no-cache"
+             "Connection" "keep-alive"}
+   :body (coro
+           (each i (range 1 50)
+             (yield (string "data: Message " i "\n\n"))
+             (ev/sleep 0.1)))})
+
+(halo2/server handler 9021 "localhost")

--- a/src/halo2.janet
+++ b/src/halo2.janet
@@ -267,9 +267,12 @@
                   file? (send-response-file stream response)
                   body-stream? (send-response-body-stream stream response)
                   bytes? (send-response stream response)
-                  :default (send-response stream {:status 500
-                                                  :body (get status-messages 500)
-                                                  :headers {"Content-Type" "text/plain"}}))))
+                  :default (do 
+                            (send-response stream 
+                              {:status 500
+                                :body (get status-messages 500)
+                                :headers {"Content-Type" "text/plain"}})
+                            (error "Response body must be bytes or a fiber stream")))))
 
             # close connection right away if Connection: close
             (when (close-connection? request)


### PR DESCRIPTION
Users can now set the :body field to a fiber, so that the server will stream the values yielded by the fiber as body.

This enables returning [Server Sent Events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events), which is a one directional way to send events to clients. It's a simpler solution for realtime communication, instead of using websockets.

I needed to use SSEs with the library [htmx](https://htmx.org)

Also, now returning a response with an invalid body (such as a table) will properly return "Internal server error", instead of just crashing the fiber handling the connection